### PR TITLE
fix: Correct display of text in encoding other than UTF-8

### DIFF
--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -321,7 +321,11 @@ class PageController extends Controller
             }
             $html = preg_replace('/' . preg_quote('cid:' . $attName) . '/ixm', $attNewSrc, $html);
         }
-        return $html;
+        if(function_exists('mb_convert_encoding')){
+            return mb_convert_encoding($html, 'html-entities', 'UTF-8');
+        } else {
+            return $html;
+        }
     }
 
     /**


### PR DESCRIPTION
The word "Сайт" in WINDOWS-1251 encoding
Before: Ð¡Ð°Ð¹Ñ
After: Сайт