### PR TITLE
Upgraded version to NC26 & fix CSS style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.8 – 2023-09-01
+Upgraded version support to NC26
+- Fixed CSS styles
+
 ## 1.0.7 – 2023-01-20
 Upgrade to zbateson/mail-mime-parser otherwise fails to load mail preview on php8   
 

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -6,7 +6,7 @@
     <summary>Preview eml files</summary>
     <description>
         <![CDATA[Provides an email preview functionality. It creates preview for the .eml files and displays it as a modal.]]></description>
-    <version>1.0.7</version>
+    <version>1.0.8</version>
     <licence>agpl</licence>
     <author mail="hello@newro.co">newroco</author>
     <namespace>EmlViewer</namespace>
@@ -17,6 +17,6 @@
     <dependencies>
         <php min-version="7.4" min-int-size="64"/>
         <lib>mbstring</lib>
-        <nextcloud min-version="24" max-version="25"/>
+        <nextcloud min-version="24" max-version="26"/>
     </dependencies>
 </info>

--- a/css/style.css
+++ b/css/style.css
@@ -14,12 +14,9 @@ li[data-id='emlviewer'] {
 }
 
 #app-sidebar.emlviewer {
-    position: fixed;
+    position: unset;
     width: 100%;
     max-width: none;
-    left: 0;
-    right: 0;
-    bottom: 0;
 }
 
 #app-sidebar.emlviewer .close {
@@ -48,12 +45,13 @@ span.close.icon-close:hover::before {
 }
 
 .emlviewer .mail-content {
+    position: relative;
     display: flex;
     height: 98%;
     margin-left: auto;
     margin-right: auto;
     text-align: left;
-    padding-left: 25px;
+    padding-left: 50px;
     padding-right: 25px;
     width: 100%;
     flex-direction: column;


### PR DESCRIPTION
1. Fix: CSS displaying content on 26 ver. NC
When displayed, the left sidebar closes part of the view
**Before:**
![before1](https://github.com/newroco/emlviewer/assets/5006170/089806bc-8973-4f19-9279-d8c865c92f0d)
![before2](https://github.com/newroco/emlviewer/assets/5006170/d10d481f-9281-45fc-9eb2-f0e5af8924b4)

**After:**
![after1](https://github.com/newroco/emlviewer/assets/5006170/c1fa3e75-e849-41c2-8fcb-c2d35a0ad0f8)
![after2](https://github.com/newroco/emlviewer/assets/5006170/73f9b85d-3903-48c9-9081-ef18a4adcd92)

2. Upgraded version support to NC26